### PR TITLE
Update CSS to make image block caption width the same as image width in figure elements.

### DIFF
--- a/css/parent-theme-modifications-default.css
+++ b/css/parent-theme-modifications-default.css
@@ -399,6 +399,9 @@ body.category header.archive-header {
 }
 
 /* Special condition for when image block uses "Full width" alignment style */
+.entry-content .alignfull {
+	width: 100% !important;
+}
 .entry-content .alignfull > figcaption{
 	width: 100%;
 	max-width: 100%;

--- a/css/parent-theme-modifications-default.css
+++ b/css/parent-theme-modifications-default.css
@@ -387,3 +387,19 @@ body.blog article:last-of-type {
 body.category header.archive-header {
 	display:none;
 }
+
+/* Set figcaption width to match figure image */
+.entry-content figure {
+	display: table !important;
+	width: auto !important;
+}
+.entry-content figure figcaption{
+	display: table-caption;
+	caption-side: bottom;
+}
+
+/* Special condition for when image block uses "Full width" alignment style */
+.entry-content .alignfull > figcaption{
+	width: 100%;
+	max-width: 100%;
+}


### PR DESCRIPTION
@jmacario-gmu - this CSS tweak should address issue #19. I don't like using the !important property but I couldn't see a way around it. Since you're more familiar with the CSS, you might be able to adjust the selector to a level of specificity that makes that unnecessary, or a generally more elegant way to handle this. 

Let me know if you have any thoughts or questions. 