### PR TITLE
Add social links to theme footer

### DIFF
--- a/css/footer-default.css
+++ b/css/footer-default.css
@@ -90,3 +90,19 @@ footer#site-footer ul#footer-menu li:last-of-type {
 footer#site-footer ul#footer-menu a {
 	color:white;
 }
+
+/* Style footer social menu */
+#site-footer .footer-social {
+	justify-content: flex-start;
+	margin-bottom: 2rem;
+}
+#site-footer ul.social-icons {
+	width: auto;
+}
+#site-footer .footer-social a {
+	width: 3.5rem;
+	height: 3.5rem;
+}
+#site-footer .footer-social svg{
+	max-width: 55%;
+}

--- a/footer.php
+++ b/footer.php
@@ -11,6 +11,7 @@
 			<footer id="site-footer" role="contentinfo" class="header-footer-group">
 
 				<div class="section-inner">
+					
 
 					<div class="footer-credits">
 
@@ -28,81 +29,85 @@
 							</a>
 						</p>
 
-						<p class="footer-slogan-address-copyright-contact">
+						<div>
+							<!-- Footer Social menu -->
+							<?php get_template_part('template-parts/menu','footer-social'); ?>
 
-							<?php
-							// Display site tagline if provided in theme customizer
-							if (get_theme_mod('gmuj_site_tagline')) {
-								echo '<!--site tagline-->';
-								echo '<span class="site-slogan">'.get_theme_mod('gmuj_site_tagline').'</span>';
-								echo '<br />';
-							}
+							<p class="footer-slogan-address-copyright-contact">
 
-							// If a custom address was *not* provided in theme customizer, use default address
-							if (!get_theme_mod('gmuj_contact_address_line_1') && !get_theme_mod('gmuj_contact_address_line_2') && !get_theme_mod('gmuj_contact_address_line_3')) {
-								echo '4400 University Drive, Fairfax, Virginia 22030<br />';
+								<?php
+								// Display site tagline if provided in theme customizer
+								if (get_theme_mod('gmuj_site_tagline')) {
+									echo '<!--site tagline-->';
+									echo '<span class="site-slogan">'.get_theme_mod('gmuj_site_tagline').'</span>';
+									echo '<br />';
+								}
+								// If a custom address was *not* provided in theme customizer, use default address
+								if (!get_theme_mod('gmuj_contact_address_line_1') && !get_theme_mod('gmuj_contact_address_line_2') && !get_theme_mod('gmuj_contact_address_line_3')) {
+									echo '4400 University Drive, Fairfax, Virginia 22030<br />';
 
-							}
-							?>
+								}
+								?>
 
-							<!--Address line 1 from theme customizer-->
-							<?php if (get_theme_mod('gmuj_contact_address_line_1')) {
-								echo get_theme_mod('gmuj_contact_address_line_1');
-								echo '<br />';
-							}
-							?>
+								<!--Address line 1 from theme customizer-->
+								<?php if (get_theme_mod('gmuj_contact_address_line_1')) {
+									echo get_theme_mod('gmuj_contact_address_line_1');
+									echo '<br />';
+								}
+								?>
 
-							<!--Address line 2 from theme customizer-->
-							<?php if (get_theme_mod('gmuj_contact_address_line_2')) {
-								echo get_theme_mod('gmuj_contact_address_line_2');
-								echo '<br />';
-							}
-							?>
+								<!--Address line 2 from theme customizer-->
+								<?php if (get_theme_mod('gmuj_contact_address_line_2')) {
+									echo get_theme_mod('gmuj_contact_address_line_2');
+									echo '<br />';
+								}
+								?>
 
-							<!--Address line 3 from theme customizer-->
-							<?php if (get_theme_mod('gmuj_contact_address_line_3')) {
-								echo get_theme_mod('gmuj_contact_address_line_3');
-								echo '<br />';
-							}
-							?>
+								<!--Address line 3 from theme customizer-->
+								<?php if (get_theme_mod('gmuj_contact_address_line_3')) {
+									echo get_theme_mod('gmuj_contact_address_line_3');
+									echo '<br />';
+								}
+								?>
 
-							<!--Contact email address from theme customizer-->
-							<?php if (get_theme_mod('gmuj_contact_email')) {
-								echo 'Email: ';
-								echo '<a href="mailto:'.get_theme_mod('gmuj_contact_email').'">'.get_theme_mod('gmuj_contact_email').'</a>';
-								echo '<br />';
-							}
-							?>
+								<!--Contact email address from theme customizer-->
+								<?php if (get_theme_mod('gmuj_contact_email')) {
+									echo 'Email: ';
+									echo '<a href="mailto:'.get_theme_mod('gmuj_contact_email').'">'.get_theme_mod('gmuj_contact_email').'</a>';
+									echo '<br />';
+								}
+								?>
 
-							<!--Contact phone number from theme customizer-->
-							<?php if (get_theme_mod('gmuj_contact_phone')) {
-								echo 'Call: ';
-								echo get_theme_mod('gmuj_contact_phone');
-								echo '<br />';
-							}
-							?>
+								<!--Contact phone number from theme customizer-->
+								<?php if (get_theme_mod('gmuj_contact_phone')) {
+									echo 'Call: ';
+									echo get_theme_mod('gmuj_contact_phone');
+									echo '<br />';
+								}
+								?>
 
-							<!--Contact fax number from theme customizer-->
-							<?php if (get_theme_mod('gmuj_contact_fax')) {
-								echo 'Fax: ';
-								echo get_theme_mod('gmuj_contact_fax');
-								echo '<br />';
-							}
-							?>
+								<!--Contact fax number from theme customizer-->
+								<?php if (get_theme_mod('gmuj_contact_fax')) {
+									echo 'Fax: ';
+									echo get_theme_mod('gmuj_contact_fax');
+									echo '<br />';
+								}
+								?>
 
-							<!--Copyright notice-->
-							&copy; <span style="font-weight:normal;"><?php echo date("Y"); ?> George Mason University</span>
-						</p>
-
-						<p class="footer-copyright">&copy;
-							<?php
-							echo date_i18n(
-								/* translators: Copyright date format, see https://secure.php.net/date */
-								_x( 'Y', 'copyright date format', 'twentytwenty' )
-							);
-							?>
-							<a href="<?php echo esc_url( home_url( '/' ) ); ?>"><?php bloginfo( 'name' ); ?></a>
-						</p><!-- .footer-copyright -->
+								<!--Copyright notice-->
+								&copy; <span style="font-weight:normal;"><?php echo date("Y"); ?> George Mason University</span>
+							</p>
+						
+							<p class="footer-copyright">&copy;
+								<?php
+								echo date_i18n(
+									/* translators: Copyright date format, see https://secure.php.net/date */
+									_x( 'Y', 'copyright date format', 'twentytwenty' )
+								);
+								?>
+								<a href="<?php echo esc_url( home_url( '/' ) ); ?>"><?php bloginfo( 'name' ); ?></a>
+							</p><!-- .footer-copyright -->
+						</div>
 
 						<p class="powered-by-wordpress">
 							<a href="<?php echo esc_url( __( 'https://wordpress.org/', 'twentytwenty' ) ); ?>">

--- a/php/custom-menus.php
+++ b/php/custom-menus.php
@@ -53,3 +53,21 @@ function menu_footer_fallback() {
 	include(get_stylesheet_directory(). '/content/menu-footer-default.html');
 
 }
+
+/**
+ * Associates correct icons with the social links automatically for the "footer social" menu location. This is necessary because the base Twentytwenty theme only supports this for the "social" menu location.
+ */
+add_filter( 'walker_nav_menu_start_el', 'mason_theme_nav_menu_social_icons', 10, 4 );
+function mason_theme_nav_menu_social_icons( $item_output, $item, $depth, $args ) {
+    // Change SVG icon inside social links menu if there is supported URL.
+    if ( 'footer-social' === $args->theme_location ) {
+        $svg = TwentyTwenty_SVG_Icons::get_social_link_svg( $item->url );
+        if ( empty( $svg ) ) {
+            $svg = twentytwenty_get_theme_svg( 'link' );
+        }
+        $item_output = str_replace( $args->link_after, '</span>' . $svg, $item_output );
+    }
+
+    return $item_output;
+    
+}

--- a/php/custom-menus.php
+++ b/php/custom-menus.php
@@ -28,7 +28,8 @@ function gmuj_register_menus(){
     register_nav_menus(array(
         'university' => 'University Menu',
         'prominent' => 'Prominent Links Menu',
-        'footer' => 'Footer Menu'
+        'footer' => 'Footer Menu',
+        'footer-social' => 'Footer Social Menu'
     ));
 
 }

--- a/template-parts/menu-footer-social.php
+++ b/template-parts/menu-footer-social.php
@@ -1,0 +1,42 @@
+<?php
+/**
+ * Associate correct icons with the social links automatically for the "footer social" menu location. 
+ * Necessary because the base Twentytwenty theme only supports this for the "social" menu location.
+ **/ 
+function mason_theme_nav_menu_social_icons( $item_output, $item, $depth, $args ) {
+	// Change SVG icon inside social links menu if there is supported URL.
+	if ( 'footer-social' === $args->theme_location ) {
+		$svg = TwentyTwenty_SVG_Icons::get_social_link_svg( $item->url );
+		if ( empty( $svg ) ) {
+			$svg = twentytwenty_get_theme_svg( 'link' );
+		}
+		$item_output = str_replace( $args->link_after, '</span>' . $svg, $item_output );
+	}
+
+	return $item_output;
+}
+add_filter( 'walker_nav_menu_start_el', 'mason_theme_nav_menu_social_icons', 10, 4 );
+?>
+
+<?php
+if ( has_nav_menu( 'footer-social' ) ) :
+?>
+<ul class="social-menu footer-social reset-list-style social-icons fill-children-current-color">
+    <?php
+    wp_nav_menu(
+        array(
+            'theme_location'  => 'footer-social',
+            'container'       => '',
+            'container_class' => '',
+            'items_wrap'      => '%3$s',
+            'menu_id'         => 'social-menu',
+            'menu_class'      => '',
+            'depth'           => 1,
+            'link_before'     => '<span class="screen-reader-text">',
+            'link_after'      => '</span>',
+            'fallback_cb'     => '',
+        )
+    );
+    ?>
+</ul><!-- .footer-social -->
+<?php endif; ?>

--- a/template-parts/menu-footer-social.php
+++ b/template-parts/menu-footer-social.php
@@ -1,23 +1,4 @@
-<?php
-/**
- * Associate correct icons with the social links automatically for the "footer social" menu location. 
- * Necessary because the base Twentytwenty theme only supports this for the "social" menu location.
- **/ 
-function mason_theme_nav_menu_social_icons( $item_output, $item, $depth, $args ) {
-	// Change SVG icon inside social links menu if there is supported URL.
-	if ( 'footer-social' === $args->theme_location ) {
-		$svg = TwentyTwenty_SVG_Icons::get_social_link_svg( $item->url );
-		if ( empty( $svg ) ) {
-			$svg = twentytwenty_get_theme_svg( 'link' );
-		}
-		$item_output = str_replace( $args->link_after, '</span>' . $svg, $item_output );
-	}
-
-	return $item_output;
-}
-add_filter( 'walker_nav_menu_start_el', 'mason_theme_nav_menu_social_icons', 10, 4 );
-?>
-
+<!-- Child theme template part for the footer social menu -->
 <?php
 if ( has_nav_menu( 'footer-social' ) ) :
 ?>


### PR DESCRIPTION
This adds a new "footer social" menu location to the theme footer. The original social menu location is unchanged, so this will be backwards compatible, and the menu can be placed in both locations if desired. 