### PR TITLE
Update horizontal rule styling to match what is used on core site/SiteMasonry platform

### DIFF
--- a/css/parent-theme-modifications.css
+++ b/css/parent-theme-modifications.css
@@ -458,7 +458,10 @@
 
 	/* style hr post separators */
 	.entry-content hr, hr.styled-separator {
-		border:1px solid #999999;
+		border: none;
+		border-bottom: 1px solid #999999;
+		height: 1px;
+		margin: 1.6rem auto;
 	}
 
 	/* remove hr accent */


### PR DESCRIPTION
Small adjustment to margins and borders of HR elements to match how they're styled on SiteMasonry. It's been noted that we internally feel that this margin is perhaps a bit small and we may bring this up with OUB at some point. 