### PR TITLE
Proposed block editor style update

### DIFF
--- a/css/editor-style-block.css
+++ b/css/editor-style-block.css
@@ -20,7 +20,7 @@ This is a template for a stylesheet that allows WordPress users to use a custom 
  h2.rich-text.block-editor-rich-text__editable,
  h3.rich-text.block-editor-rich-text__editable,
  h4.rich-text.block-editor-rich-text__editable,
- h5.rich-text.block-editor-rich-text__editable,
+ h5.rich-text.block-editor-rich-text__editable
  h6.rich-text.block-editor-rich-text__editable,
  .has-medium-font-size,
  #post-title-0
@@ -83,10 +83,12 @@ h4.rich-text.block-editor-rich-text__editable {
 
 h5.rich-text.block-editor-rich-text__editable {
     font-size: 25px;
+    color: #333;
 }
 
 h6.rich-text.block-editor-rich-text__editable {
     font-size: 20px;
+    color: #333;
 }
  
  p.rich-text.block-editor-rich-text__editable {
@@ -156,7 +158,7 @@ cite {
 
  /* Standard Wordpress Details block */
  details.block-editor-block-list__block > summary {
-    font-family: Palatino Linotype, Palatino, serif;
+    font-family: 'Open Sans', sans-serif;
     color: #005239;
     font-size: 24px;
     font-weight: bold;
@@ -168,4 +170,7 @@ details.block-editor-block-list__block > :not(summary) {
     padding: 0;
   }
 
- 
+ /* Columns block in block editor */
+ .block-editor-block-list__block .wp-block-column {
+    border: dotted 1px #333;
+  }


### PR DESCRIPTION
@jmacario-gmu: In my experience, it can be somewhat difficult to work with columns blocks because they're essentially invisible in the block editor until one is selected. I propose adding a dotted border around the individual columns. 

This PR also contains the following minor edits to the block editor:

- Update h5 and h6 block colors to match theme
- Change details block summary font to sans-serif.